### PR TITLE
Use Google NTP server for reliability

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -179,6 +179,7 @@ int main() {
     LogInfo("Getting time from the NTP server");
 
     NTPClient ntp(_defaultSystemNetwork);
+    ntp.set_server("time.google.com", 123);
     time_t timestamp = ntp.get_timestamp();
     if (timestamp < 0) {
         LogError("Failed to get the current time, error: %ld", timestamp);


### PR DESCRIPTION
Credits to @rajkan01 
The default NTP client used by the [NTPClient library](https://github.com/ARMmbed/ntp-client) has a high chance of not responding, so we use the one from Google.