### PR TITLE
Add test log and instructions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -196,9 +196,5 @@ int main() {
     demo();
     LogInfo("The demo has ended");
 
-    while (true) {
-        sleep();
-    }
-
     return 0;
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Testing examples
+
+Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log.
+
+To run the test, use following command after you build the example:
+```
+mbedhtrun -d /Volumes/DIS_L4IOT/ -p /dev/tty.usbmodem1432403 -m DISCO_L475VG_IOT01A -f ./BUILD/DISCO_L475VG_IOT01A/GCC_ARM/mbed-os-example-for-azure.bin --compare-log tests/azure.log --baud-rate=115200 --sync=0
+```
+
+
+More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).

--- a/tests/azure.log
+++ b/tests/azure.log
@@ -1,0 +1,14 @@
+Info: Connecting to the network
+Info: Connection success, MAC: .*
+Info: Getting time from the NTP server
+Info: Time: .*
+
+Info: RTC reports .*
+
+Info: Starting the Demo
+Info: Initializing IoT Hub client
+Info: Sending: "10 messages left to send, or until we receive a reply"
+Info: Connected to IoT Hub
+.*
+Info: Sending: "1 messages left to send, or until we receive a reply"
+Info: Message sent successfully


### PR DESCRIPTION
For now, reply messages from the cloud is not supported. We can easily add a few lines to the log once we've configured message routing on the IoT Hub (to be decided & separate task).

@ARMmbed/mbed-os-core 