### PR TITLE
Do not require RTC, as time is fetched from NTP server

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -186,11 +186,7 @@ int main() {
         return -1;
     }
     LogInfo("Time: %s", ctime(&timestamp));
-
-    rtc_init();
-    rtc_write(timestamp);
-    time_t rtc_timestamp = rtc_read(); // verify it's been successfully updated
-    LogInfo("RTC reports %s", ctime(&rtc_timestamp));
+    set_time(timestamp);
 
     LogInfo("Starting the Demo");
     demo();


### PR DESCRIPTION
Unblocks: #11 

This change aligns with the way [mbed-os-example-for-google-iot-cloud](https://github.com/ARMmbed/mbed-os-example-for-google-iot-cloud) sets time.

I've tested that timing and cloud connection continue to work correctly.