### PR TITLE
CMake: Add cmakelists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,105 @@
+# Copyright (c) 2020 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: sh
+os: linux
+dist: xenial
+
+env:
+  global:
+    - PROFILE=develop
+
+cache:
+  pip: true
+  ccache: true
+  # It looks like ccache for arm-none-eabi is not yet supported by Travis.
+  # Therefore manually adding ccache directory to cache
+  directories:
+    - ${HOME}/.ccache
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
+    packages:
+      - cmake
+      - ninja-build
+
+matrix:
+  include:
+
+    - &cmake-build-test
+      stage: "CMake"
+      name: "CMake Azure IoT Hub example - develop (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=develop  CACHE_NAME=develop-K64F
+      language: python
+      python: 3.8
+      install:
+        # Setup ccache
+        - ccache -o compiler_check=content
+        - ccache -M 1G
+        - pushd /usr/lib/ccache
+        - sudo ln -s ../../bin/ccache arm-none-eabi-gcc
+        - sudo ln -s ../../bin/ccache arm-none-eabi-g++
+        - export PATH="/usr/lib/ccache:$PATH"
+        - popd
+        # Install arm-none-eabi-gcc
+        - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A" --output gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - tar xf gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        - popd
+        - arm-none-eabi-gcc --version
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
+        - pip install --upgrade mbed-tools
+        - pip install prettytable==0.7.2
+        - pip install future==0.16.0
+        - pip install "Jinja2>=2.10.1,<2.11"
+        - pip install "intelhex>=1.3,<=2.2.1"
+      script:
+        - mbedtools checkout
+        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - ccache -s
+
+    - <<: *cmake-build-test
+      name: "CMake Azure IoT Hub example - release (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=release CACHE_NAME=release-K64F
+
+    - <<: *cmake-build-test
+      name: "CMake Azure IoT Hub example - debug (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=debug CACHE_NAME=debug-K64F
+
+    - <<: *cmake-build-test
+      name: "CMake Azure IoT Hub example - develop (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=develop CACHE_NAME=develop-DISCO_L475VG_IOT01A
+
+    - <<: *cmake-build-test
+      name: "CMake Azure IoT Hub example - release (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=release CACHE_NAME=release-DISCO_L475VG_IOT01A
+
+    - <<: *cmake-build-test
+      name: "CMake Azure IoT Hub example - debug (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=debug CACHE_NAME=debug-DISCO_L475VG_IOT01A

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET mbed-os-example-for-azure)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(${MBED_PATH})
+add_subdirectory(mbed-client-for-azure)
+add_subdirectory(ntp-client)
+add_subdirectory(drivers/COMPONENT_wifi_ism43362)
+
+add_executable(${APP_TARGET})
+
+mbed_configure_app_target(${APP_TARGET})
+
+mbed_set_mbed_target_linker_script(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_include_directories(${APP_TARGET}
+    PRIVATE
+        .
+)
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        mbed-client-for-azure
+        mbed-os
+        wifi-ism43362
+        ntp-client
+        mbed-mbedtls
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,10 @@ include(${MBED_PATH}/tools/cmake/app.cmake)
 add_subdirectory(${MBED_PATH})
 add_subdirectory(mbed-client-for-azure)
 add_subdirectory(ntp-client)
-add_subdirectory(drivers/COMPONENT_wifi_ism43362)
+
+if("wifi_ism43362" IN_LIST MBED_TARGET_LABELS)
+    add_subdirectory(drivers/COMPONENT_wifi_ism43362)
+endif()
 
 add_executable(${APP_TARGET})
 
@@ -32,11 +35,17 @@ target_sources(${APP_TARGET}
         main.cpp
 )
 
+if("wifi_ism43362" IN_LIST MBED_TARGET_LABELS)
+    target_link_libraries(${APP_TARGET}
+        PRIVATE
+            wifi-ism43362
+    )
+endif()
+
 target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-client-for-azure
         mbed-os
-        wifi-ism43362
         ntp-client
         mbed-mbedtls
 )

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To fetch the example,
 
     **Note**: Please _ignore_ warnings like `Could not access submodule ...` and `[mbed] WARNING: File "package.bld" in ...`. They are caused by different dependency control systems used by the Azure SDK and Mbed CLI.
 
-1. In the example repository you fetched, open [`mbed_app.json`](./mbed_app.json) and set the value of `iothub_connection_string` to the Primary Connection String you [previously copied](#setting-up-the-cloud), keeping any escaped quotes (`\"`).
+1. In the example repository you fetched, open [`azure_cloud_credentials.h`](./azure_cloud_credentials.h) and place `Primary Connection String` which you have [previously copied](#setting-up-the-cloud) into `iothub_connection_string` array.
 1. (If you want to use *WiFi*) set `nsapi.default-wifi-ssid` to your WiFi name and `nsapi.default-wifi-password` to your WiFi password, keeping any escaped quotes (`\"`). If you use a different target, replace `"DISCO_L475VG_IOT01A"` with your target and remove `"target.components_add": ["wifi_ism43362"]` (unless it use the same ISM43362 WiFi module).
     For example, to use NUCLEO-F429ZI:
     ```json

--- a/azure_cloud_credentials.h
+++ b/azure_cloud_credentials.h
@@ -1,0 +1,17 @@
+/*
+ * Google Cloud Certificates
+ * Copyright (c) 2019-2020, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef AZURE_CLOUD_CREDENTIALS_H
+#define AZURE_CLOUD_CREDENTIALS_H
+
+namespace azure_cloud {
+namespace credentials {
+/*
+ * Primary Connecion String
+ */
+char iothub_connection_string[] = "HostName=...;DeviceId=...;SharedAccessKey=...";
+}
+}
+#endif

--- a/drivers/COMPONENT_wifi_ism43362.lib
+++ b/drivers/COMPONENT_wifi_ism43362.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-ism43362/#9e1851a7fe5e2ffb07533aacc7114df2e73f7784
+https://github.com/ARMmbed/wifi-ism43362/#ee466577559ec733e5d3c88c55517a40cb03f537

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@
 #include "azure_c_shared_utility/xlogging.h"
 
 #include "iothubtransportmqtt.h"
+#include "azure_cloud_credentials.h"
 
 /**
  * This example sends and receives messages to and from Azure IoT Hub.
@@ -65,7 +66,6 @@ static void on_message_sent(IOTHUB_CLIENT_CONFIRMATION_RESULT result, void* user
 }
 
 void demo() {
-    static const char connection_string[] = MBED_CONF_APP_IOTHUB_CONNECTION_STRING;
     bool trace_on = MBED_CONF_APP_IOTHUB_CLIENT_TRACE;
     tickcounter_ms_t interval = 100;
     IOTHUB_CLIENT_RESULT res;
@@ -74,7 +74,7 @@ void demo() {
     IoTHub_Init();
 
     IOTHUB_DEVICE_CLIENT_HANDLE client_handle = IoTHubDeviceClient_CreateFromConnectionString(
-        connection_string,
+        azure_cloud::credentials::iothub_connection_string,
         MQTT_Protocol
     );
     if (client_handle == nullptr) {

--- a/mbed-client-for-azure.lib
+++ b/mbed-client-for-azure.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-client-for-azure#16f9b31e41c1bb89b776418b6dc109b92b0d911c
+https://github.com/ARMmbed/mbed-client-for-azure#25e348a3a14209a7f6ef47557afbcc71f942af4e

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,9 +1,5 @@
 {
     "config": {
-        "iothub_connection_string": {
-            "help": "Azure IoT Hub connection string",
-            "value": "\"HostName=...;DeviceId=...;SharedAccessKey=...\""
-        },
         "iothub_client_trace": {
             "help": "Enable IoT Hub Client tracing",
             "value": false

--- a/ntp-client.lib
+++ b/ntp-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/ntp-client.git#a4ccf62992b9adc5086a9afea08fa4deb2e2fbd7
+https://github.com/ARMmbed/ntp-client.git#e919cfb14e2029efafc0d1288a0223cbd09811f0


### PR DESCRIPTION
 - Add CMake support and update `mbed-os.lib` to pick the latest master
- Update `COMPONENT_wifi_ism43362.lib` to latest to pick CMake changes
-  In `mbed_app.json` `iothub_connection_string` config is copied from Azure cloud but CMake at preprocessing time it divides connection string into multiple `#define` string macros because of the semicolon which leads to building failure so moved connection string from `mbed_app.json` into the header file.

@0xc0170 @hugueskamba @linlingao @evedon 