### PR TITLE
Build EP_AGORA in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,5 +14,5 @@ jobs:
       - run: |
           cd mbed-os-example-for-azure
           mbed deploy
-          mbed compile -t GCC_ARM -m K64F
+          mbed compile -t GCC_ARM -m EP_AGORA
 


### PR DESCRIPTION
Other targets (K64F, DISCO_L475VG_IOT01A) are covered by Travis CI and built with the new CMake/mbed-tools. This commit is for temporary coverage of EP_AGORA, until it gets CMake support.