### PR TITLE
Fix build with Mbed CLI 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ matrix:
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
-set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-for-azure)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
@@ -18,10 +18,6 @@ if("wifi_ism43362" IN_LIST MBED_TARGET_LABELS)
 endif()
 
 add_executable(${APP_TARGET})
-
-mbed_configure_app_target(${APP_TARGET})
-
-mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ You can build the project with all supported [Mbed OS build tools](https://os.mb
 
 It has been tested on K64F with Ethernet and DISCO_L475VG_IOT01A with WiFi, but any Mbed OS 6 targets with Internet access should work.
 
+## Mbed OS build tools
+
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-for-azure`
+1. Change the current directory to where the project was imported.
+
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+1. From the command-line, import the example: `mbed import mbed-os-example-for-azure`
+1. Change the current directory to where the project was imported.
+
 ## Setting up an Azure IoT Hub account
 
 Follow Azure IoT Hub's official documentation to
@@ -47,9 +60,19 @@ To compile and run the example,
 1. Connect your development board to your PC with a USB cable.
 1. (If you want to use Ethernet) connect the board to an Ethernet cable of your network.
 1. Compile, flash and run the example
+
+    * Mbed CLI 2
+
+    ```bash
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm --baudrate=115200
     ```
-    mbed compile -m <TARGET> -t <TOOLCHAIN> -f --sterm --baud 115200
+
+    * Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm --baudrate=115200
     ```
+
     For example, `<TARGET>` can be `DISCO_L475VG_IOT01A` and `<TOOLCHAIN>` can be `GCC_ARM` if you want to use this combination.
 
 ## Expected output

--- a/drivers/COMPONENT_wifi_ism43362.lib
+++ b/drivers/COMPONENT_wifi_ism43362.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-ism43362/#ee466577559ec733e5d3c88c55517a40cb03f537
+https://github.com/ARMmbed/wifi-ism43362/#3813a4bb8623cc9b0525978748581f60d47142fa


### PR DESCRIPTION
Mbed CLI 2 (mbed-tools and CMake support) has been in development for some time and seen some changes. This example's CMake definitions need to be updated accordingly:

`.travis.yml`:
* Update mbed-tools commands

`drivers/COMPONENT_wifi_ism43362.lib`:
* Use the latest version to bring in compilation fixes

`CMakeLists.txt`:
* Update the configuration path generated by mbed-tools
* Remove mbed_set_mbed_target_linker_script() call which is no longer present in Mbed OS

`README.md`:
* Add instructions for Mbed CLI 2

Fixes #26